### PR TITLE
chore: downsize App Platform containers and fix CI deploy triggers

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -7,7 +7,7 @@ services:
   - name: write-service
     http_port: 3000
     instance_count: 1
-    instance_size_slug: basic-xs
+    instance_size_slug: basic-xxs
     routes:
       - path: /xq-fitness-write-service
         preserve_path_prefix: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'src/**'
+      - '.do/**'
       - 'package.json'
       - 'Dockerfile'
       - '.github/workflows/ci.yml'


### PR DESCRIPTION
## Summary
- Downsize DigitalOcean App Platform instance from `basic-xs` to `basic-xxs` to reduce hosting costs
- Add `.do/**` to CI push path filters so changes to the App Platform spec trigger deployment on merge

## Test plan
- [ ] Merge PR and verify CI workflow runs on push to main
- [ ] Confirm App Platform redeploys with `basic-xxs` instance size
- [ ] Smoke-test write-service health endpoint after deploy