### PR TITLE
Merge read APIs into write-service (unified v2.1.0 contract)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'src/**'
       - 'api/**'
+      - 'test/**'
       - 'openapitools.json'
       - 'scripts/generate-api-client.sh'
       - '.do/**'
@@ -22,6 +23,7 @@ on:
     paths:
       - 'src/**'
       - 'api/**'
+      - 'test/**'
       - 'openapitools.json'
       - 'scripts/generate-api-client.sh'
       - '.do/**'

--- a/README.md
+++ b/README.md
@@ -1,151 +1,40 @@
 # XQ Fitness Write Service
 
-Node.js service for creating, updating, and deleting workout data.
+Unified backend for XQ Fitness read and write APIs. All endpoints are defined in [`api/write-service-api.yaml`](api/write-service-api.yaml).
 
-[![Build Test Publish Deploy](https://github.com/chauhaidang/xq-fitness-write/actions/workflows/ci.yml/badge.svg)](https://github.com/chauhaidang/xq-fitness-write/actions/workflows/ci.yml)
+Gateway path: `/xq-fitness-write-service/api/v1`
 
-[![Sync API Definition to xq-apis](https://github.com/chauhaidang/xq-fitness-write/actions/workflows/api-sync.yml/badge.svg)](https://github.com/chauhaidang/xq-fitness-write/actions/workflows/api-sync.yml)
-
-### [Test summary report](https://chauhaidang.github.io/xq-fitness-write/)
-
-## Prerequisites
-
-- Node.js 20 with Corepack
-- PostgreSQL 12+
-- Docker with BuildKit (optional, for containerized deployment)
-- A `GITHUB_TOKEN` with read access to the private `@chauhaidang` packages
-
-## Quick Start
-
-### Local Development
-
-1. Enable the pinned Yarn version, generate the local API client, and install dependencies:
+## Local development
 
 ```bash
-export GITHUB_TOKEN=<github-packages-read-token>
 corepack enable
+export GITHUB_TOKEN=...   # required for private packages
 ./scripts/generate-api-client.sh write-service
 yarn install --immutable
-```
-
-2. Create environment file:
-
-```bash
-cp .env.example .env
-```
-
-3. Update the `.env` file with your database credentials
-
-4. Make sure the database schema is already created (see the read-service README)
-
-5. Run the service:
-
-```bash
-# Development mode with auto-reload
+yarn build
 yarn dev
-
-# Production mode
-yarn start
 ```
 
-The service will start on port 3000 (or the port specified in `.env`).
-
-### Docker Deployment
-
-#### Using Docker Compose (Recommended)
-
-From the project root, run:
+## Tests
 
 ```bash
-docker-compose up -d
+yarn test:unit
+yarn test:component:local   # requires xq-infra
+yarn test:all
 ```
 
-This starts all services including the database, read-service, and write-service.
+## Deployment
 
-#### Using Pre-built GHCR Images
+DigitalOcean App Platform via `.github/workflows/ci.yml`. Updates **write-service** component only; read-service on DO is retired manually after soak.
 
-Pull and run the latest published image:
+### Manual read-service retirement (post-soak)
 
-```bash
-docker run -d \
-  --name xq-write-service \
-  -p 3000:3000 \
-  -e DATABASE_HOST=host.docker.internal \
-  -e DATABASE_PORT=5432 \
-  -e DATABASE_NAME=xq_fitness \
-  -e DATABASE_USER=xq_user \
-  -e DATABASE_PASSWORD=xq_password \
-  -e NODE_ENV=production \
-  ghcr.io/chauhaidang/xq-fitness-write-service:latest
-```
+After merged write-service is deployed and mobile reads use `/xq-fitness-write-service`:
 
-#### Building Docker Image Locally
+1. Verify component tests pass on the write path (`yarn test:component:local` or CI).
+2. Smoke production: `GET .../xq-fitness-write-service/api/v1/muscle-groups`, weekly report, create routine, snapshot.
+3. Keep the read-service DO component running during soak for rollback.
+4. Remove read-service from the `xq-fitness` app in the DO console (or `doctl apps update` with an edited spec). **Do not** automate this in CI.
+5. Optionally archive `xq-fitness-read` GitHub repo and disable read-service CI.
 
-```bash
-export GITHUB_TOKEN=<github-packages-read-token>
-./build-write-service.sh
-docker run -d \
-  --name xq-write-service \
-  -p 3000:3000 \
-  -e DATABASE_HOST=host.docker.internal \
-  -e DATABASE_PORT=5432 \
-  -e DATABASE_NAME=xq_fitness \
-  -e DATABASE_USER=xq_user \
-  -e DATABASE_PASSWORD=xq_password \
-  -e NODE_ENV=production \
-  xq-fitness-write-service:latest
-```
-
-## API Endpoints
-
-Base URL: `http://localhost:3000/api/v1`
-
-### Routines
-
-- `POST /routines` - Create a new routine
-- `PUT /routines/{id}` - Update a routine
-- `DELETE /routines/{id}` - Delete a routine
-
-### Workout Days
-
-- `POST /workout-days` - Create a workout day
-- `PUT /workout-days/{id}` - Update a workout day
-- `DELETE /workout-days/{id}` - Delete a workout day
-
-### Workout Day Sets
-
-- `POST /workout-day-sets` - Add sets configuration
-- `PUT /workout-day-sets/{id}` - Update sets configuration
-- `DELETE /workout-day-sets/{id}` - Delete sets configuration
-
-### Snapshots
-
-- `POST /routines/{routineId}/snapshots` - Create a weekly snapshot for a routine
-  - Creates a snapshot of the current routine data (workout days and sets) for the current week
-  - Resets all sets (`numberOfSets`) to zero after snapshot creation
-  - If a snapshot already exists for the current week, it will be replaced
-  - Returns the created snapshot with `id`, `routineId`, `weekStartDate`, and `createdAt`
-
-## Docker Image Publishing
-
-This service is automatically published to GitHub Container Registry (GHCR) on every push to the `main` branch.
-
-### Image Tags
-
-- `latest` - Most recent build from main branch
-- `main-<commit-sha>` - Specific commit version (e.g., `main-abc1234f`)
-
-### Pulling Published Images
-
-```bash
-docker pull ghcr.io/chauhaidang/xq-fitness-write-service:latest
-docker pull ghcr.io/chauhaidang/xq-fitness-write-service:main-abc1234f
-```
-
-### GitHub Actions Workflow
-
-See `.github/workflows/ci.yml` for the build, test, publish, and deploy workflow.
-
-## API Documentation
-
-See the OpenAPI specification at `./api/write-service-api.yaml`.
+The nginx `/xq-fitness-read-service/` alias can remain as a safety net until all clients are updated.

--- a/api/write-service-api.yaml
+++ b/api/write-service-api.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
-  title: XQ Fitness Write Service API
-  description: Write service for creating, updating, and deleting workout routines and related data
-  version: 1.3.1
+  title: XQ Fitness API
+  description: Unified read and write API for workout routines and related data
+  version: 2.1.0
   contact:
     name: XQ Fitness Team
 
@@ -11,7 +11,58 @@ servers:
     description: Local development server
 
 paths:
+  /muscle-groups:
+    get:
+      summary: Get all muscle groups
+      description: Retrieves a list of all available muscle groups
+      operationId: getMuscleGroups
+      tags:
+        - Muscle Groups
+      responses:
+        '200':
+          description: Successfully retrieved muscle groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MuscleGroup'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /routines:
+    get:
+      summary: Get all workout routines
+      description: Retrieves a list of all workout routines
+      operationId: getRoutines
+      tags:
+        - Routines
+      parameters:
+        - name: isActive
+          in: query
+          description: Filter by active status
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successfully retrieved routines
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkoutRoutine'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     post:
       summary: Create a new workout routine
       description: Creates a new workout routine
@@ -45,6 +96,40 @@ paths:
                 $ref: '#/components/schemas/Error'
 
   /routines/{routineId}:
+    get:
+      summary: Get a specific workout routine
+      description: |
+        Retrieves a workout routine with all its days, sets configuration (deprecated), and exercises.
+      operationId: getRoutineById
+      tags:
+        - Routines
+      parameters:
+        - name: routineId
+          in: path
+          description: ID of the routine to retrieve
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Successfully retrieved routine
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkoutRoutineDetail'
+        '404':
+          description: Routine not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     put:
       summary: Update a workout routine
       description: Updates an existing workout routine
@@ -238,6 +323,49 @@ paths:
                 $ref: '#/components/schemas/Error'
 
   /exercises:
+    get:
+      summary: Get exercises for a workout day
+      description: |
+        Retrieves exercises for a workout day, optionally filtered by muscle group.
+      operationId: getExercises
+      tags:
+        - Exercises
+      parameters:
+        - name: workoutDayId
+          in: query
+          description: Filter by workout day (required)
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: muscleGroupId
+          in: query
+          description: Filter by muscle group (optional)
+          required: false
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Successfully retrieved exercises
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Exercise'
+        '400':
+          description: Invalid request (missing workoutDayId)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     post:
       summary: Create a new exercise
       description: |
@@ -535,6 +663,86 @@ paths:
           description: Sets configuration deleted successfully
         '404':
           description: Sets configuration not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /routines/{routineId}/days:
+    get:
+      summary: Get all workout days for a routine
+      description: Retrieves all workout days for a specific routine
+      operationId: getWorkoutDays
+      tags:
+        - Workout Days
+      parameters:
+        - name: routineId
+          in: path
+          description: ID of the routine
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Successfully retrieved workout days
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkoutDayDetail'
+        '404':
+          description: Routine not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /routines/{routineId}/weekly-report:
+    get:
+      summary: Get weekly report for a routine
+      description: |
+        Retrieves a weekly report showing total sets per muscle group and exercise-level totals.
+      operationId: getWeeklyReport
+      tags:
+        - Reports
+      parameters:
+        - name: routineId
+          in: path
+          description: ID of the routine to get report for
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: weekStartDate
+          in: query
+          description: Optional week start date (Monday) in ISO 8601 format (YYYY-MM-DD)
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: Weekly report retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeeklyReportResponse'
+        '404':
+          description: Routine not found
           content:
             application/json:
               schema:
@@ -951,6 +1159,249 @@ components:
           format: date-time
           description: Timestamp when the snapshot was created
           example: "2024-12-07T10:30:00Z"
+
+    MuscleGroup:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 13
+        name:
+          type: string
+          example: "Abductor"
+        description:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    WorkoutRoutine:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        description:
+          type: string
+        isActive:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    WorkoutRoutineDetail:
+      allOf:
+        - $ref: '#/components/schemas/WorkoutRoutine'
+        - type: object
+          properties:
+            workoutDays:
+              type: array
+              items:
+                $ref: '#/components/schemas/WorkoutDayDetail'
+
+    WorkoutDay:
+      type: object
+      required:
+        - id
+        - routineId
+        - dayNumber
+        - dayName
+      properties:
+        id:
+          type: integer
+          format: int64
+        routineId:
+          type: integer
+          format: int64
+        dayNumber:
+          type: integer
+        dayName:
+          type: string
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    WorkoutDayDetail:
+      allOf:
+        - $ref: '#/components/schemas/WorkoutDay'
+        - type: object
+          properties:
+            sets:
+              type: array
+              items:
+                $ref: '#/components/schemas/WorkoutDaySet'
+            exercises:
+              type: array
+              items:
+                $ref: '#/components/schemas/Exercise'
+
+    WorkoutDaySet:
+      type: object
+      required:
+        - id
+        - workoutDayId
+        - muscleGroup
+        - numberOfSets
+      properties:
+        id:
+          type: integer
+          format: int64
+        workoutDayId:
+          type: integer
+          format: int64
+        muscleGroup:
+          $ref: '#/components/schemas/MuscleGroup'
+        numberOfSets:
+          type: integer
+          minimum: 1
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    WeeklyReportResponse:
+      type: object
+      required:
+        - routineId
+        - weekStartDate
+        - hasSnapshot
+        - muscleGroupTotals
+        - exerciseTotals
+      properties:
+        routineId:
+          type: integer
+          format: int64
+        weekStartDate:
+          type: string
+          format: date
+        hasSnapshot:
+          type: boolean
+        snapshotCreatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        muscleGroupTotals:
+          type: array
+          items:
+            $ref: '#/components/schemas/MuscleGroupTotal'
+        exerciseTotals:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExerciseTotal'
+
+    MuscleGroupTotal:
+      type: object
+      required:
+        - muscleGroup
+        - totalSets
+      properties:
+        muscleGroup:
+          $ref: '#/components/schemas/MuscleGroup'
+        totalSets:
+          type: integer
+          minimum: 0
+
+    Exercise:
+      type: object
+      required:
+        - id
+        - workoutDayId
+        - muscleGroupId
+        - exerciseName
+        - totalReps
+        - weight
+        - totalSets
+      properties:
+        id:
+          type: integer
+          format: int64
+        workoutDayId:
+          type: integer
+          format: int64
+        muscleGroupId:
+          type: integer
+          format: int64
+        exerciseName:
+          type: string
+        muscleGroup:
+          $ref: '#/components/schemas/MuscleGroup'
+        totalReps:
+          type: integer
+          format: int64
+          minimum: 0
+        weight:
+          type: number
+          format: decimal
+          minimum: 0
+        totalSets:
+          type: integer
+          format: int64
+          minimum: 0
+        notes:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ExerciseTotal:
+      type: object
+      required:
+        - exerciseName
+        - muscleGroup
+        - totalReps
+        - totalWeight
+      properties:
+        exerciseName:
+          type: string
+        muscleGroup:
+          $ref: '#/components/schemas/MuscleGroup'
+        totalReps:
+          type: integer
+          format: int64
+          minimum: 0
+        totalWeight:
+          type: number
+          format: decimal
+          minimum: 0
+        progressStatusRep:
+          type: string
+          enum:
+            - INCREASED
+            - DECREASED
+            - MAINTAINED
+          nullable: true
+        progressStatusWeight:
+          type: string
+          enum:
+            - INCREASED
+            - DECREASED
+            - MAINTAINED
+          nullable: true
 
     Error:
       type: object

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xq-fitness-write-service",
-  "version": "2.0.1",
-  "description": "Write service for XQ Fitness application",
+  "version": "2.1.0",
+  "description": "Unified read and write API for XQ Fitness",
   "main": "dist/src/index.js",
   "scripts": {
     "build": "tsc",
@@ -47,6 +47,7 @@
     "@types/joi": "^17.2.2",
     "@types/node": "^22.5.0",
     "@types/pg": "^8.16.0",
+    "@types/supertest": "^6.0.3",
     "@types/wait-on": "^5.3.4",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/src/controllers/readController.ts
+++ b/src/controllers/readController.ts
@@ -1,0 +1,73 @@
+import type { Request, Response } from 'express';
+import * as readService from '../services/readService';
+
+export async function getMuscleGroups(_req: Request, res: Response): Promise<void> {
+  const data = await readService.getAllMuscleGroups();
+  res.json(data);
+}
+
+export async function getRoutines(req: Request, res: Response): Promise<void> {
+  const isActiveParam = req.query.isActive;
+  let isActive: boolean | undefined;
+  if (isActiveParam === 'true') isActive = true;
+  else if (isActiveParam === 'false') isActive = false;
+  const data = await readService.getAllRoutines(isActive);
+  res.json(data);
+}
+
+export async function getRoutineById(req: Request, res: Response): Promise<void> {
+  const routineId = parseInt(String(req.params.routineId), 10);
+  if (Number.isNaN(routineId)) {
+    res.status(400).json({ code: 'BAD_REQUEST', message: 'Invalid routineId', timestamp: new Date().toISOString() });
+    return;
+  }
+  const data = await readService.getRoutineById(routineId);
+  if (!data) {
+    res.status(404).json({ code: 'NOT_FOUND', message: 'Routine not found', timestamp: new Date().toISOString() });
+    return;
+  }
+  res.json(data);
+}
+
+export async function getWorkoutDays(req: Request, res: Response): Promise<void> {
+  const routineId = parseInt(String(req.params.routineId), 10);
+  if (Number.isNaN(routineId)) {
+    res.status(400).json({ code: 'BAD_REQUEST', message: 'Invalid routineId', timestamp: new Date().toISOString() });
+    return;
+  }
+  const data = await readService.getWorkoutDaysByRoutineId(routineId);
+  if (data.length === 0) {
+    res.status(404).json({ code: 'NOT_FOUND', message: 'Routine not found', timestamp: new Date().toISOString() });
+    return;
+  }
+  res.json(data);
+}
+
+export async function getExercises(req: Request, res: Response): Promise<void> {
+  const workoutDayIdParam = req.query.workoutDayId;
+  if (workoutDayIdParam === undefined || workoutDayIdParam === '') {
+    res.status(400).json({
+      code: 'BAD_REQUEST',
+      message: 'workoutDayId is required',
+      timestamp: new Date().toISOString(),
+    });
+    return;
+  }
+  const workoutDayId = parseInt(String(workoutDayIdParam), 10);
+  if (Number.isNaN(workoutDayId)) {
+    res.status(400).json({
+      code: 'BAD_REQUEST',
+      message: 'Invalid workoutDayId',
+      timestamp: new Date().toISOString(),
+    });
+    return;
+  }
+  const muscleGroupIdParam = req.query.muscleGroupId;
+  let muscleGroupId: number | undefined;
+  if (muscleGroupIdParam !== undefined && muscleGroupIdParam !== '') {
+    muscleGroupId = parseInt(String(muscleGroupIdParam), 10);
+    if (Number.isNaN(muscleGroupId)) muscleGroupId = undefined;
+  }
+  const data = await readService.getExercisesByWorkoutDayId(workoutDayId, muscleGroupId);
+  res.json(data);
+}

--- a/src/controllers/reportController.ts
+++ b/src/controllers/reportController.ts
@@ -1,0 +1,26 @@
+import type { Request, Response } from 'express';
+import * as reportService from '../services/reportService';
+
+export async function getWeeklyReport(req: Request, res: Response): Promise<void> {
+  const routineId = parseInt(String(req.params.routineId), 10);
+  if (Number.isNaN(routineId)) {
+    res.status(400).json({ code: 'BAD_REQUEST', message: 'Invalid routineId', timestamp: new Date().toISOString() });
+    return;
+  }
+  const weekStartDate = req.query.weekStartDate as string | undefined;
+  try {
+    const data = await reportService.getWeeklyReport(routineId, weekStartDate);
+    res.json(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    if (message.includes('Routine not found')) {
+      res.status(404).json({ code: 'NOT_FOUND', message, timestamp: new Date().toISOString() });
+      return;
+    }
+    res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import { validate } from '../middleware/validator';
 import * as schemas from '../validators/schemas';
+import * as readController from '../controllers/readController';
+import * as reportController from '../controllers/reportController';
 import { RoutineController } from '../controllers/routineController';
 import { WorkoutDayController } from '../controllers/workoutDayController';
 import { WorkoutDaySetController } from '../controllers/workoutDaySetController';
@@ -9,6 +11,15 @@ import { SnapshotController } from '../controllers/snapshotController';
 
 const router = express.Router();
 
+// Read routes
+router.get('/muscle-groups', readController.getMuscleGroups);
+router.get('/routines', readController.getRoutines);
+router.get('/routines/:routineId', readController.getRoutineById);
+router.get('/routines/:routineId/days', readController.getWorkoutDays);
+router.get('/routines/:routineId/weekly-report', reportController.getWeeklyReport);
+router.get('/exercises', readController.getExercises);
+
+// Write routes
 router.post('/routines', validate(schemas.createRoutineSchema), RoutineController.createRoutine);
 router.put('/routines/:routineId', validate(schemas.updateRoutineSchema), RoutineController.updateRoutine);
 router.delete('/routines/:routineId', RoutineController.deleteRoutine);

--- a/src/services/readService.ts
+++ b/src/services/readService.ts
@@ -1,0 +1,194 @@
+import { query } from '../config/database';
+import type {
+  MuscleGroup,
+  WorkoutRoutine,
+  WorkoutRoutineDetail,
+  WorkoutDayDetail,
+  WorkoutDaySet,
+  Exercise,
+} from '../types/dto';
+
+function toIsoDate(val: Date | null | undefined): string | undefined {
+  if (!val) return undefined;
+  const d = val instanceof Date ? val : new Date(val);
+  return isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+export async function getAllMuscleGroups(): Promise<MuscleGroup[]> {
+  const result = await query(
+    'SELECT id, name, description, created_at FROM muscle_groups ORDER BY name'
+  );
+  return (result.rows as { id: number; name: string; description: string | null; created_at: Date }[]).map(
+    (row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description ?? undefined,
+      createdAt: toIsoDate(row.created_at),
+    })
+  );
+}
+
+export async function getAllRoutines(isActive?: boolean): Promise<WorkoutRoutine[]> {
+  let sql = 'SELECT id, name, description, is_active, created_at, updated_at FROM workout_routines';
+  const params: unknown[] = [];
+  if (isActive !== undefined && isActive !== null) {
+    sql += ' WHERE is_active = $1';
+    params.push(isActive);
+  }
+  sql += ' ORDER BY id';
+  const result = await query(sql, params.length ? params : undefined);
+  return (result.rows as { id: number; name: string; description: string | null; is_active: boolean; created_at: Date; updated_at: Date }[]).map(
+    (row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description ?? undefined,
+      isActive: row.is_active,
+      createdAt: toIsoDate(row.created_at),
+      updatedAt: toIsoDate(row.updated_at),
+    })
+  );
+}
+
+export async function getRoutineById(id: number): Promise<WorkoutRoutineDetail | null> {
+  const routineResult = await query(
+    'SELECT id, name, description, is_active, created_at, updated_at FROM workout_routines WHERE id = $1',
+    [id]
+  );
+  if (routineResult.rows.length === 0) return null;
+  const r = routineResult.rows[0] as { id: number; name: string; description: string | null; is_active: boolean; created_at: Date; updated_at: Date };
+  const days = await getWorkoutDaysByRoutineId(id);
+  return {
+    id: r.id,
+    name: r.name,
+    description: r.description ?? undefined,
+    isActive: r.is_active,
+    createdAt: toIsoDate(r.created_at),
+    updatedAt: toIsoDate(r.updated_at),
+    workoutDays: days,
+  };
+}
+
+export async function getWorkoutDaysByRoutineId(routineId: number): Promise<WorkoutDayDetail[]> {
+  const daysResult = await query(
+    `SELECT d.id, d.routine_id AS "routineId", d.day_number AS "dayNumber", d.day_name AS "dayName", d.notes, d.created_at, d.updated_at
+     FROM workout_days d
+     WHERE d.routine_id = $1
+     ORDER BY d.day_number`,
+    [routineId]
+  );
+  const days = daysResult.rows as {
+    id: number;
+    routineId: number;
+    dayNumber: number;
+    dayName: string;
+    notes: string | null;
+    created_at: Date;
+    updated_at: Date;
+  }[];
+  const out: WorkoutDayDetail[] = [];
+  for (const day of days) {
+    const sets = await getSetsForWorkoutDay(day.id);
+    const exercises = await getExercisesByWorkoutDayId(day.id);
+    out.push({
+      id: day.id,
+      routineId: day.routineId,
+      dayNumber: day.dayNumber,
+      dayName: day.dayName,
+      notes: day.notes ?? undefined,
+      createdAt: toIsoDate(day.created_at),
+      updatedAt: toIsoDate(day.updated_at),
+      sets,
+      exercises,
+    });
+  }
+  return out;
+}
+
+async function getSetsForWorkoutDay(workoutDayId: number): Promise<WorkoutDaySet[]> {
+  const result = await query(
+    `SELECT s.id, s.workout_day_id AS "workoutDayId", s.number_of_sets AS "numberOfSets", s.notes, s.created_at, s.updated_at,
+            mg.id AS "mg_id", mg.name AS "mg_name", mg.description AS "mg_description", mg.created_at AS "mg_created_at"
+     FROM workout_day_sets s
+     JOIN muscle_groups mg ON mg.id = s.muscle_group_id
+     WHERE s.workout_day_id = $1
+     ORDER BY s.id`,
+    [workoutDayId]
+  );
+  return (result.rows as {
+    id: number;
+    workoutDayId: number;
+    numberOfSets: number;
+    notes: string | null;
+    created_at: Date;
+    updated_at: Date;
+    mg_id: number;
+    mg_name: string;
+    mg_description: string | null;
+    mg_created_at: Date;
+  }[]).map((row) => ({
+    id: row.id,
+    workoutDayId: row.workoutDayId,
+    muscleGroup: {
+      id: row.mg_id,
+      name: row.mg_name,
+      description: row.mg_description ?? undefined,
+      createdAt: toIsoDate(row.mg_created_at),
+    },
+    numberOfSets: row.numberOfSets,
+    notes: row.notes ?? undefined,
+    createdAt: toIsoDate(row.created_at),
+    updatedAt: toIsoDate(row.updated_at),
+  }));
+}
+
+export async function getExercisesByWorkoutDayId(
+  workoutDayId: number,
+  muscleGroupId?: number
+): Promise<Exercise[]> {
+  let sql = `SELECT e.id, e.workout_day_id AS "workoutDayId", e.muscle_group_id AS "muscleGroupId", e.exercise_name AS "exerciseName",
+             e.total_reps AS "totalReps", e.weight, e.total_sets AS "totalSets", e.notes, e.created_at, e.updated_at,
+             mg.id AS "mg_id", mg.name AS "mg_name", mg.description AS "mg_description", mg.created_at AS "mg_created_at"
+             FROM exercises e
+             JOIN muscle_groups mg ON mg.id = e.muscle_group_id
+             WHERE e.workout_day_id = $1`;
+  const params: unknown[] = [workoutDayId];
+  if (muscleGroupId !== undefined && muscleGroupId !== null) {
+    sql += ' AND e.muscle_group_id = $2';
+    params.push(muscleGroupId);
+  }
+  sql += ' ORDER BY e.id';
+  const result = await query(sql, params);
+  return (result.rows as {
+    id: number;
+    workoutDayId: number;
+    muscleGroupId: number;
+    exerciseName: string;
+    totalReps: number;
+    weight: string | number;
+    totalSets: number;
+    notes: string | null;
+    created_at: Date;
+    updated_at: Date;
+    mg_id: number;
+    mg_name: string;
+    mg_description: string | null;
+    mg_created_at: Date;
+  }[]).map((row) => ({
+    id: row.id,
+    workoutDayId: row.workoutDayId,
+    muscleGroupId: row.muscleGroupId,
+    exerciseName: row.exerciseName,
+    muscleGroup: {
+      id: row.mg_id,
+      name: row.mg_name,
+      description: row.mg_description ?? undefined,
+      createdAt: toIsoDate(row.mg_created_at),
+    },
+    totalReps: row.totalReps,
+    weight: typeof row.weight === 'string' ? parseFloat(row.weight) : row.weight,
+    totalSets: row.totalSets,
+    notes: row.notes ?? undefined,
+    createdAt: toIsoDate(row.created_at),
+    updatedAt: toIsoDate(row.updated_at),
+  }));
+}

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,0 +1,277 @@
+import { query } from '../config/database';
+import type {
+  WeeklyReportResponse,
+  MuscleGroupTotal,
+  ExerciseTotal,
+  MuscleGroup,
+} from '../types/dto';
+
+function toIsoDate(val: Date | null | undefined): string | undefined {
+  if (!val) return undefined;
+  const d = val instanceof Date ? val : new Date(val);
+  return isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+/** Monday of the week containing date (ISO 8601). Uses UTC. */
+export function calculateWeekStart(date: Date): string {
+  const d = new Date(date);
+  const utcDay = d.getUTCDay();
+  const daysToSubtract = utcDay === 0 ? 6 : utcDay - 1;
+  d.setUTCDate(d.getUTCDate() - daysToSubtract);
+  return d.toISOString().slice(0, 10);
+}
+
+export async function getWeeklyReport(
+  routineId: number,
+  weekStartDate?: string
+): Promise<WeeklyReportResponse> {
+  const existsResult = await query('SELECT 1 FROM workout_routines WHERE id = $1', [routineId]);
+  if (existsResult.rows.length === 0) {
+    throw new Error('Routine not found: ' + routineId);
+  }
+
+  const weekStart = weekStartDate ?? calculateWeekStart(new Date());
+
+  const currentSnapshotData = await getSnapshotDataForWeek(routineId, weekStart);
+
+  if (currentSnapshotData) {
+    const { snapshot, snapshotExercises } = currentSnapshotData;
+    const exerciseTotals = buildExerciseTotals(snapshotExercises);
+
+    const prevDate = new Date(weekStart);
+    prevDate.setUTCDate(prevDate.getUTCDate() - 7);
+    const prevWeekStart = prevDate.toISOString().slice(0, 10);
+
+    const prevSnapshotData = await getSnapshotDataForWeek(routineId, prevWeekStart);
+    let prevExerciseTotals: ExerciseTotal[] = [];
+    if (prevSnapshotData) {
+      prevExerciseTotals = buildExerciseTotals(prevSnapshotData.snapshotExercises);
+    }
+
+    for (const currentExercise of exerciseTotals) {
+      const prevExercise = prevExerciseTotals.find(
+        (e) => e.exerciseName === currentExercise.exerciseName && e.muscleGroup.id === currentExercise.muscleGroup.id
+      );
+
+      if (prevExercise) {
+        if (currentExercise.totalReps > prevExercise.totalReps) {
+          currentExercise.progressStatusRep = 'INCREASED';
+        } else if (currentExercise.totalReps < prevExercise.totalReps) {
+          currentExercise.progressStatusRep = 'DECREASED';
+        } else {
+          currentExercise.progressStatusRep = 'MAINTAINED';
+        }
+
+        if (currentExercise.totalWeight > prevExercise.totalWeight) {
+          currentExercise.progressStatusWeight = 'INCREASED';
+        } else if (currentExercise.totalWeight < prevExercise.totalWeight) {
+          currentExercise.progressStatusWeight = 'DECREASED';
+        } else {
+          currentExercise.progressStatusWeight = 'MAINTAINED';
+        }
+      } else {
+        currentExercise.progressStatusRep = 'MAINTAINED';
+        currentExercise.progressStatusWeight = 'MAINTAINED';
+      }
+    }
+
+    const muscleGroupTotals =
+      snapshotExercises.length === 0
+        ? await aggregateSetsByMuscleGroup(routineId, weekStart)
+        : await aggregateMuscleGroupTotalsFromExercises(snapshotExercises);
+
+    return {
+      routineId,
+      weekStartDate: weekStart,
+      hasSnapshot: true,
+      snapshotCreatedAt: toIsoDate(snapshot.created_at),
+      muscleGroupTotals,
+      exerciseTotals,
+    };
+  }
+
+  const muscleGroupTotals = await getAllMuscleGroupsWithZeroSets();
+  return {
+    routineId,
+    weekStartDate: weekStart,
+    hasSnapshot: false,
+    snapshotCreatedAt: null,
+    muscleGroupTotals,
+    exerciseTotals: [],
+  };
+}
+
+async function getSnapshotDataForWeek(routineId: number, weekStart: string) {
+  const snapshotResult = await query(
+    'SELECT id, created_at FROM weekly_snapshots WHERE routine_id = $1 AND week_start_date = $2',
+    [routineId, weekStart]
+  );
+
+  if (snapshotResult.rows.length === 0) {
+    return null;
+  }
+
+  const snapshot = snapshotResult.rows[0] as { id: number; created_at: Date };
+  const snapshotWorkoutDayIds = await getSnapshotWorkoutDayIds(snapshot.id);
+
+  let snapshotExercises: {
+    exercise_name: string;
+    muscle_group_id: number;
+    mg_name: string;
+    mg_description: string | null;
+    mg_created_at: Date;
+    total_reps: number;
+    weight: string | number;
+    total_sets: number;
+  }[] = [];
+
+  if (snapshotWorkoutDayIds.length > 0) {
+    const placeholders = snapshotWorkoutDayIds.map((_, i) => `$${i + 1}`).join(',');
+    const exResult = await query(
+      `SELECT se.exercise_name, se.muscle_group_id, se.total_reps, se.weight, se.total_sets,
+              mg.name AS mg_name, mg.description AS mg_description, mg.created_at AS mg_created_at
+       FROM snapshot_exercises se
+       JOIN muscle_groups mg ON mg.id = se.muscle_group_id
+       WHERE se.snapshot_workout_day_id IN (${placeholders})
+       ORDER BY se.id`,
+      snapshotWorkoutDayIds
+    );
+    snapshotExercises = exResult.rows as typeof snapshotExercises;
+  }
+
+  return { snapshot, snapshotExercises };
+}
+
+async function getSnapshotWorkoutDayIds(snapshotId: number): Promise<number[]> {
+  const result = await query(
+    'SELECT id FROM snapshot_workout_days WHERE snapshot_id = $1',
+    [snapshotId]
+  );
+  return (result.rows as { id: number }[]).map((r) => r.id);
+}
+
+function buildExerciseTotals(
+  rows: {
+    exercise_name: string;
+    muscle_group_id: number;
+    mg_name: string;
+    mg_description: string | null;
+    mg_created_at: Date;
+    total_reps: number;
+    weight: string | number;
+    total_sets: number;
+  }[]
+): ExerciseTotal[] {
+  const byKey = new Map<
+    string,
+    { name: string; muscleGroup: MuscleGroup; totalReps: number; totalWeight: number }
+  >();
+  for (const row of rows) {
+    const key = `${row.exercise_name}|${row.muscle_group_id}`;
+    const weight = typeof row.weight === 'string' ? parseFloat(row.weight) : row.weight;
+    const mg: MuscleGroup = {
+      id: row.muscle_group_id,
+      name: row.mg_name,
+      description: row.mg_description ?? undefined,
+      createdAt: toIsoDate(row.mg_created_at),
+    };
+    const existing = byKey.get(key);
+    const totalWeight = Number.isFinite(weight) ? (weight as number) : 0;
+    if (existing) {
+      if (totalWeight > existing.totalWeight) {
+        existing.totalWeight = totalWeight;
+        existing.totalReps = row.total_reps;
+      } else if (totalWeight === existing.totalWeight) {
+        existing.totalReps = Math.max(existing.totalReps, row.total_reps);
+      }
+    } else {
+      byKey.set(key, {
+        name: row.exercise_name,
+        muscleGroup: mg,
+        totalReps: row.total_reps,
+        totalWeight,
+      });
+    }
+  }
+  return Array.from(byKey.values()).map((v) => ({
+    exerciseName: v.name,
+    muscleGroup: v.muscleGroup,
+    totalReps: v.totalReps,
+    totalWeight: v.totalWeight,
+  }));
+}
+
+async function aggregateSetsByMuscleGroup(
+  routineId: number,
+  weekStartDate: string
+): Promise<MuscleGroupTotal[]> {
+  const result = await query(
+    `SELECT mg.id AS muscle_group_id, mg.name AS muscle_group_name, mg.description AS muscle_group_description,
+            mg.created_at AS muscle_group_created_at, COALESCE(SUM(swds.number_of_sets), 0)::int AS total_sets
+     FROM muscle_groups mg
+     LEFT JOIN snapshot_workout_day_sets swds ON mg.id = swds.muscle_group_id
+     LEFT JOIN snapshot_workout_days swd ON swds.snapshot_workout_day_id = swd.id
+     LEFT JOIN weekly_snapshots ws ON swd.snapshot_id = ws.id AND ws.routine_id = $1 AND ws.week_start_date = $2
+     WHERE swds.id IS NULL OR ws.id IS NOT NULL
+     GROUP BY mg.id, mg.name, mg.description, mg.created_at
+     ORDER BY mg.name`,
+    [routineId, weekStartDate]
+  );
+  return (result.rows as { muscle_group_id: number; muscle_group_name: string; muscle_group_description: string | null; muscle_group_created_at: Date; total_sets: number }[]).map(
+    (row) => ({
+      muscleGroup: {
+        id: row.muscle_group_id,
+        name: row.muscle_group_name,
+        description: row.muscle_group_description ?? undefined,
+        createdAt: toIsoDate(row.muscle_group_created_at),
+      },
+      totalSets: row.total_sets,
+    })
+  );
+}
+
+async function getAllMuscleGroupsWithZeroSets(): Promise<MuscleGroupTotal[]> {
+  const result = await query(
+    'SELECT id, name, description, created_at FROM muscle_groups ORDER BY name'
+  );
+  return (result.rows as { id: number; name: string; description: string | null; created_at: Date }[]).map(
+    (row) => ({
+      muscleGroup: {
+        id: row.id,
+        name: row.name,
+        description: row.description ?? undefined,
+        createdAt: toIsoDate(row.created_at),
+      },
+      totalSets: 0,
+    })
+  );
+}
+
+async function aggregateMuscleGroupTotalsFromExercises(
+  rows: {
+    muscle_group_id: number;
+    mg_name: string;
+    mg_description: string | null;
+    mg_created_at: Date;
+    total_sets: number;
+  }[]
+): Promise<MuscleGroupTotal[]> {
+  const setsByMgId = new Map<number, number>();
+  for (const row of rows) {
+    setsByMgId.set(row.muscle_group_id, (setsByMgId.get(row.muscle_group_id) ?? 0) + row.total_sets);
+  }
+  const allMgResult = await query(
+    'SELECT id, name, description, created_at FROM muscle_groups ORDER BY name'
+  );
+  return (allMgResult.rows as { id: number; name: string; description: string | null; created_at: Date }[]).map(
+    (row) => ({
+      muscleGroup: {
+        id: row.id,
+        name: row.name,
+        description: row.description ?? undefined,
+        createdAt: toIsoDate(row.created_at),
+      },
+      totalSets: setsByMgId.get(row.id) ?? 0,
+    })
+  );
+}

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -1,0 +1,89 @@
+/**
+ * DTOs matching write-service-api.yaml (OpenAPI) read response shapes.
+ * Date fields as ISO 8601 strings.
+ */
+
+export interface MuscleGroup {
+  id: number;
+  name: string;
+  description?: string;
+  createdAt?: string;
+}
+
+export interface WorkoutRoutine {
+  id: number;
+  name: string;
+  description?: string;
+  isActive: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface WorkoutDaySet {
+  id: number;
+  workoutDayId: number;
+  muscleGroup: MuscleGroup;
+  numberOfSets: number;
+  notes?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface Exercise {
+  id: number;
+  workoutDayId: number;
+  muscleGroupId: number;
+  exerciseName: string;
+  muscleGroup: MuscleGroup;
+  totalReps: number;
+  weight: number;
+  totalSets: number;
+  notes?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface WorkoutDayDetail {
+  id: number;
+  routineId: number;
+  dayNumber: number;
+  dayName: string;
+  notes?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  sets: WorkoutDaySet[];
+  exercises: Exercise[];
+}
+
+export interface WorkoutRoutineDetail extends WorkoutRoutine {
+  workoutDays: WorkoutDayDetail[];
+}
+
+export interface MuscleGroupTotal {
+  muscleGroup: MuscleGroup;
+  totalSets: number;
+}
+
+export interface ExerciseTotal {
+  exerciseName: string;
+  muscleGroup: MuscleGroup;
+  totalReps: number;
+  totalWeight: number;
+  progressStatusRep?: 'INCREASED' | 'DECREASED' | 'MAINTAINED' | null;
+  progressStatusWeight?: 'INCREASED' | 'DECREASED' | 'MAINTAINED' | null;
+}
+
+export interface WeeklyReportResponse {
+  routineId: number;
+  weekStartDate: string;
+  hasSnapshot: boolean;
+  snapshotCreatedAt?: string | null;
+  muscleGroupTotals: MuscleGroupTotal[];
+  exerciseTotals: ExerciseTotal[];
+}
+
+export interface ErrorResponse {
+  code: string;
+  message: string;
+  timestamp?: string;
+}

--- a/test/component/helpers/api-client.ts
+++ b/test/component/helpers/api-client.ts
@@ -5,36 +5,48 @@
 
 import {
   Configuration,
+  MuscleGroupsApi,
   RoutinesApi,
   WorkoutDaysApi,
   WorkoutDaySetsApi,
   ExercisesApi,
   SnapshotsApi,
+  ReportsApi,
   RoutineResponse,
   WorkoutDayResponse,
   WorkoutDaySetResponse,
   ExerciseResponse,
   WeeklySnapshotResponse,
+  MuscleGroup,
+  WorkoutRoutine,
+  WorkoutRoutineDetail,
+  WorkoutDayDetail,
+  WeeklyReportResponse,
+  Exercise,
 } from 'xq-fitness-write-client';
 import { logger } from '@chauhaidang/xq-harness-common-kit';
 
 export class ApiClient {
+  private muscleGroupsApi: MuscleGroupsApi;
   private routinesApi: RoutinesApi;
   private workoutDaysApi: WorkoutDaysApi;
   private workoutDaySetsApi: WorkoutDaySetsApi;
   private exercisesApi: ExercisesApi;
   private snapshotsApi: SnapshotsApi;
+  private reportsApi: ReportsApi;
 
   constructor(baseUrl: string) {
     const config = new Configuration({
       basePath: baseUrl,
     });
 
+    this.muscleGroupsApi = new MuscleGroupsApi(config);
     this.routinesApi = new RoutinesApi(config);
     this.workoutDaysApi = new WorkoutDaysApi(config);
     this.workoutDaySetsApi = new WorkoutDaySetsApi(config);
     this.exercisesApi = new ExercisesApi(config);
     this.snapshotsApi = new SnapshotsApi(config);
+    this.reportsApi = new ReportsApi(config);
   }
 
   /**
@@ -313,5 +325,35 @@ export class ApiClient {
     } catch (error) {
       return await this.handleError(`delete exercise ${id}`, error);
     }
+  }
+
+  async getMuscleGroups(): Promise<MuscleGroup[]> {
+    const res = await this.muscleGroupsApi.getMuscleGroups();
+    return res.data;
+  }
+
+  async getRoutines(isActive?: boolean): Promise<WorkoutRoutine[]> {
+    const res = await this.routinesApi.getRoutines(isActive);
+    return res.data;
+  }
+
+  async getRoutineById(routineId: number): Promise<WorkoutRoutineDetail> {
+    const res = await this.routinesApi.getRoutineById(routineId);
+    return res.data;
+  }
+
+  async getWorkoutDays(routineId: number): Promise<WorkoutDayDetail[]> {
+    const res = await this.workoutDaysApi.getWorkoutDays(routineId);
+    return res.data;
+  }
+
+  async getWeeklyReport(routineId: number, weekStartDate?: string): Promise<WeeklyReportResponse> {
+    const res = await this.reportsApi.getWeeklyReport(routineId, weekStartDate);
+    return res.data;
+  }
+
+  async getExercises(workoutDayId: number, muscleGroupId?: number): Promise<Exercise[]> {
+    const res = await this.exercisesApi.getExercises(workoutDayId, muscleGroupId);
+    return res.data;
   }
 }

--- a/test/component/helpers/db-fixture.ts
+++ b/test/component/helpers/db-fixture.ts
@@ -1,0 +1,185 @@
+/**
+ * Database fixture for component tests (read workflows).
+ * Uses DatabaseHelper from @chauhaidang/xq-test-utils; seeds data and cleans up.
+ */
+
+import { DatabaseHelper, type DatabaseConfig } from './database';
+
+const DB_CONFIG: DatabaseConfig = {
+  host: 'localhost',
+  port: 5432,
+  database: 'xq_fitness',
+  user: 'xq_user',
+  password: 'xq_password',
+  ssl: false,
+};
+
+let dbHelper: DatabaseHelper | null = null;
+
+function getHelper(): DatabaseHelper {
+  if (!dbHelper) {
+    throw new Error('db-fixture not initialized: call initDbFixture() in setup');
+  }
+  return dbHelper;
+}
+
+async function query(text: string, params?: unknown[]): Promise<{ rows: unknown[] }> {
+  return getHelper().query(text, params);
+}
+
+export async function initDbFixture(): Promise<void> {
+  if (dbHelper) return;
+  dbHelper = new DatabaseHelper(DB_CONFIG);
+  await dbHelper.connect();
+  const healthCheck = await dbHelper.healthCheck([
+    'workout_routines',
+    'workout_days',
+    'weekly_snapshots',
+    'snapshot_exercises',
+  ]);
+  if (!healthCheck.healthy) {
+    throw new Error(
+      `Database health check failed. Connection: ${healthCheck.connection}, Schema: ${healthCheck.schema}`
+    );
+  }
+}
+
+export async function closeDbFixture(): Promise<void> {
+  if (dbHelper) {
+    await dbHelper.disconnect();
+    dbHelper = null;
+  }
+}
+
+export function getCurrentWeekStart(): string {
+  const d = new Date();
+  const utcDay = d.getUTCDay();
+  const daysToSubtract = utcDay === 0 ? 6 : utcDay - 1;
+  d.setUTCDate(d.getUTCDate() - daysToSubtract);
+  return d.toISOString().slice(0, 10);
+}
+
+export function getPreviousWeekStart(weeksAgo: number = 1): string {
+  const d = new Date();
+  const utcDay = d.getUTCDay();
+  const daysToSubtract = (utcDay === 0 ? 6 : utcDay - 1) + weeksAgo * 7;
+  d.setUTCDate(d.getUTCDate() - daysToSubtract);
+  return d.toISOString().slice(0, 10);
+}
+
+export async function createRoutine(
+  name: string,
+  description: string | null,
+  isActive: boolean
+): Promise<number> {
+  const result = await query(
+    'INSERT INTO workout_routines (name, description, is_active, created_at, updated_at) VALUES ($1, $2, $3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id',
+    [name, description, isActive]
+  );
+  return (result.rows[0] as { id: number }).id;
+}
+
+export async function createWorkoutDay(
+  routineId: number,
+  dayNumber: number,
+  dayName: string,
+  notes: string | null
+): Promise<number> {
+  const result = await query(
+    'INSERT INTO workout_days (routine_id, day_number, day_name, notes, created_at, updated_at) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id',
+    [routineId, dayNumber, dayName, notes]
+  );
+  return (result.rows[0] as { id: number }).id;
+}
+
+export async function createWorkoutDaySet(
+  workoutDayId: number,
+  muscleGroupId: number,
+  numberOfSets: number,
+  notes: string | null
+): Promise<number> {
+  const result = await query(
+    'INSERT INTO workout_day_sets (workout_day_id, muscle_group_id, number_of_sets, notes, created_at, updated_at) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id',
+    [workoutDayId, muscleGroupId, numberOfSets, notes]
+  );
+  return (result.rows[0] as { id: number }).id;
+}
+
+export async function createSnapshot(routineId: number, weekStart: string): Promise<number> {
+  const result = await query(
+    'INSERT INTO weekly_snapshots (routine_id, week_start_date, created_at, updated_at) VALUES ($1, $2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP) RETURNING id',
+    [routineId, weekStart]
+  );
+  return (result.rows[0] as { id: number }).id;
+}
+
+export async function createSnapshotWorkoutDay(
+  snapshotId: number,
+  originalWorkoutDayId: number,
+  dayNumber: number,
+  dayName: string,
+  notes: string | null
+): Promise<number> {
+  const result = await query(
+    'INSERT INTO snapshot_workout_days (snapshot_id, original_workout_day_id, day_number, day_name, notes, created_at) VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP) RETURNING id',
+    [snapshotId, originalWorkoutDayId, dayNumber, dayName, notes]
+  );
+  return (result.rows[0] as { id: number }).id;
+}
+
+export async function createSnapshotWorkoutDaySet(
+  snapshotWorkoutDayId: number,
+  originalWorkoutDaySetId: number,
+  muscleGroupId: number,
+  numberOfSets: number,
+  notes: string | null
+): Promise<number> {
+  const result = await query(
+    'INSERT INTO snapshot_workout_day_sets (snapshot_workout_day_id, original_workout_day_set_id, muscle_group_id, number_of_sets, notes, created_at) VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP) RETURNING id',
+    [snapshotWorkoutDayId, originalWorkoutDaySetId, muscleGroupId, numberOfSets, notes]
+  );
+  return (result.rows[0] as { id: number }).id;
+}
+
+export async function createSnapshotExercise(
+  snapshotWorkoutDayId: number,
+  originalExerciseId: number,
+  exerciseName: string,
+  muscleGroupId: number,
+  totalReps: number,
+  weight: number,
+  totalSets: number,
+  notes: string | null
+): Promise<number> {
+  const result = await query(
+    'INSERT INTO snapshot_exercises (snapshot_workout_day_id, original_exercise_id, exercise_name, muscle_group_id, total_reps, weight, total_sets, notes, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, CURRENT_TIMESTAMP) RETURNING id',
+    [snapshotWorkoutDayId, originalExerciseId, exerciseName, muscleGroupId, totalReps, weight, totalSets, notes]
+  );
+  return (result.rows[0] as { id: number }).id;
+}
+
+export async function routineExists(routineId: number): Promise<boolean> {
+  const result = await query('SELECT 1 FROM workout_routines WHERE id = $1', [routineId]);
+  return result.rows.length > 0;
+}
+
+export async function deleteRoutine(routineId: number): Promise<void> {
+  await query(
+    'DELETE FROM snapshot_exercises WHERE snapshot_workout_day_id IN (SELECT id FROM snapshot_workout_days WHERE snapshot_id IN (SELECT id FROM weekly_snapshots WHERE routine_id = $1))',
+    [routineId]
+  );
+  await query(
+    'DELETE FROM snapshot_workout_day_sets WHERE snapshot_workout_day_id IN (SELECT id FROM snapshot_workout_days WHERE snapshot_id IN (SELECT id FROM weekly_snapshots WHERE routine_id = $1))',
+    [routineId]
+  );
+  await query(
+    'DELETE FROM snapshot_workout_days WHERE snapshot_id IN (SELECT id FROM weekly_snapshots WHERE routine_id = $1)',
+    [routineId]
+  );
+  await query('DELETE FROM weekly_snapshots WHERE routine_id = $1', [routineId]);
+  await query('DELETE FROM workout_day_sets WHERE workout_day_id IN (SELECT id FROM workout_days WHERE routine_id = $1)', [
+    routineId,
+  ]);
+  await query('DELETE FROM workout_days WHERE routine_id = $1', [routineId]);
+  await query('DELETE FROM workout_routines WHERE id = $1', [routineId]);
+}

--- a/test/component/setup.ts
+++ b/test/component/setup.ts
@@ -1,33 +1,32 @@
 /**
  * Global setup for Component tests
- * Waits for API to be ready before running tests
  */
 
 import { waitForService } from '@chauhaidang/xq-test-utils';
 import { logger } from '@chauhaidang/xq-harness-common-kit';
+import { initDbFixture, closeDbFixture } from './helpers/db-fixture';
 
-// Force local DB for component tests (override .env - xq-infra exposes DB on localhost:5432)
 process.env.DB_HOST = '127.0.0.1';
 process.env.DB_PORT = '5432';
 process.env.DB_NAME = 'xq_fitness';
 process.env.DB_USER = 'xq_user';
 process.env.DB_PASSWORD = 'xq_password';
 
-// Get base URL from environment or use default (test-env gateway entry point)
 const BASE_URL = process.env.API_BASE_URL || 'http://localhost:8080/xq-fitness-write-service/api/v1';
 const HEALTH_CHECK_URL = process.env.HEALTH_CHECK_URL || 'http://localhost:8080/xq-fitness-write-service/health';
 
-// Global setup - runs once before all tests
 beforeAll(async () => {
   logger.info('🚀 Starting Component test suite');
   logger.info(`Base URL: ${BASE_URL}`);
   logger.info(`Health Check URL: ${HEALTH_CHECK_URL}`);
 
   try {
-    // Wait for API to be ready
     logger.info('⏳ Waiting for API server to be ready...');
     await waitForService(HEALTH_CHECK_URL, { timeout: 30000, interval: 1000 });
     logger.info('✅ API server is ready');
+
+    await initDbFixture();
+    logger.info('✅ Database fixture ready');
   } catch (error) {
     logger.error('❌ API server failed to start within timeout');
     logger.error(`Error: ${error}`);
@@ -35,7 +34,7 @@ beforeAll(async () => {
   }
 });
 
-// Global teardown marker - runs after all tests
-afterAll(() => {
+afterAll(async () => {
+  await closeDbFixture();
   logger.info('🏁 Component test suite completed');
 });

--- a/test/component/teardown.ts
+++ b/test/component/teardown.ts
@@ -5,6 +5,7 @@
 
 import { generateTestReport } from '@chauhaidang/xq-test-utils';
 import { logger } from '@chauhaidang/xq-harness-common-kit';
+import { closeDbFixture } from './helpers/db-fixture';
 
 /** Markdown section with detailed description of Exercise CRUD component tests */
 function getExerciseTestDetailSection(): string {
@@ -27,6 +28,13 @@ export default async (): Promise<void> => {
   logger.info('🧹 Component-Teardown: Running global teardown');
 
   // Close database connection pool to prevent Jest from hanging
+  try {
+    await closeDbFixture();
+    logger.info('✅ Database fixture closed');
+  } catch (error) {
+    logger.warn('⚠️ Could not close database fixture:', error);
+  }
+
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires -- dynamic require for optional DB teardown
     const db = require('../../src/config/database');

--- a/test/component/workflows/exercises-list.test.ts
+++ b/test/component/workflows/exercises-list.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Component tests: GET /exercises (list)
+ */
+
+import * as db from '../helpers/db-fixture';
+import { ApiClient } from '../helpers/api-client';
+
+const BASE_URL = process.env.API_BASE_URL || 'http://localhost:8080/xq-fitness-write-service/api/v1';
+const apiClient = new ApiClient(BASE_URL);
+
+const routineIdsToClean: number[] = [];
+
+afterEach(async () => {
+  for (const id of routineIdsToClean) {
+    try {
+      await db.deleteRoutine(id);
+    } catch (_e) {
+      // ignore
+    }
+  }
+  routineIdsToClean.length = 0;
+});
+
+describe('Component Test: Exercises list', () => {
+  test('GET /exercises?workoutDayId=X returns 200', async () => {
+    const routineId = await db.createRoutine('Exercises Routine', null, true);
+    routineIdsToClean.push(routineId);
+    const dayId = await db.createWorkoutDay(routineId, 1, 'Push Day', null);
+
+    const body = await apiClient.getExercises(dayId);
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  test('GET /exercises without workoutDayId returns 400', async () => {
+    const res = await fetch(`${BASE_URL}/exercises`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/test/component/workflows/health.test.ts
+++ b/test/component/workflows/health.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Component Test: Health endpoint
+ */
+
+import { logger } from '@chauhaidang/xq-harness-common-kit';
+import { ApiClient } from '../helpers/api-client';
+
+const BASE_URL = process.env.API_BASE_URL || 'http://localhost:8080/xq-fitness-write-service/api/v1';
+const HEALTH_URL = process.env.HEALTH_CHECK_URL || 'http://localhost:8080/xq-fitness-write-service/health';
+
+const apiClient = new ApiClient(BASE_URL);
+
+describe('Component Test: Health', () => {
+  test('health endpoint returns 200', async () => {
+    const res = await fetch(HEALTH_URL);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; service: string };
+    expect(body.status).toBe('UP');
+    expect(body.service).toBe('xq-fitness-write-service');
+    logger.info('✅ Health check passed');
+  });
+
+  test('muscle-groups endpoint returns 200', async () => {
+    const body = await apiClient.getMuscleGroups();
+    expect(Array.isArray(body)).toBe(true);
+    logger.info('✅ Muscle groups check passed');
+  });
+});

--- a/test/component/workflows/routines.test.ts
+++ b/test/component/workflows/routines.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Component tests: GET /routines, GET /routines/:id, GET /routines/:id/days
+ */
+
+import { logger } from '@chauhaidang/xq-harness-common-kit';
+import * as db from '../helpers/db-fixture';
+import { ApiClient } from '../helpers/api-client';
+
+const BASE_URL = process.env.API_BASE_URL || 'http://localhost:8080/xq-fitness-write-service/api/v1';
+const apiClient = new ApiClient(BASE_URL);
+
+const routineIdsToClean: number[] = [];
+
+afterEach(async () => {
+  for (const id of routineIdsToClean) {
+    try {
+      await db.deleteRoutine(id);
+    } catch (e) {
+      logger.warn(`Cleanup routine ${id} failed: ${e}`);
+    }
+  }
+  routineIdsToClean.length = 0;
+});
+
+describe('Component Test: Routines', () => {
+  test('GET /muscle-groups returns 200 and array', async () => {
+    const body = await apiClient.getMuscleGroups();
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  test('GET /routines returns routine created via DB', async () => {
+    const routineId = await db.createRoutine('Component Test Routine', 'Description', true);
+    routineIdsToClean.push(routineId);
+
+    const body = await apiClient.getRoutines();
+    expect(Array.isArray(body)).toBe(true);
+    const found = body.find((r) => r.id === routineId);
+    expect(found).toBeDefined();
+    expect(found!.name).toBe('Component Test Routine');
+    expect(found!.isActive).toBe(true);
+  });
+
+  test('GET /routines?isActive=true returns only active', async () => {
+    const activeId = await db.createRoutine('Active Routine', null, true);
+    const inactiveId = await db.createRoutine('Inactive Routine', null, false);
+    routineIdsToClean.push(activeId, inactiveId);
+
+    const body = await apiClient.getRoutines(true);
+    expect(Array.isArray(body)).toBe(true);
+    body.forEach((r) => expect(r.isActive).toBe(true));
+    expect(body.some((r) => r.id === activeId)).toBe(true);
+  });
+
+  test('GET /routines/:id returns 200 with days and exercises', async () => {
+    const routineId = await db.createRoutine('Detail Test Routine', null, true);
+    routineIdsToClean.push(routineId);
+    const dayId = await db.createWorkoutDay(routineId, 1, 'Push Day', null);
+    await db.createWorkoutDaySet(dayId, 1, 3, null);
+
+    const body = await apiClient.getRoutineById(routineId);
+    expect(body.id).toBe(routineId);
+    expect(body.name).toBe('Detail Test Routine');
+    expect(body.workoutDays).toBeDefined();
+    const days = body.workoutDays!;
+    expect(days.length).toBe(1);
+    const day = days[0]!;
+    expect(day.dayName).toBe('Push Day');
+    expect(day.sets).toBeDefined();
+    expect(day.sets!.length).toBe(1);
+    expect(day.sets![0]!.numberOfSets).toBe(3);
+  });
+
+  test('GET /routines/:id returns 404 for non-existent', async () => {
+    await expect(apiClient.getRoutineById(999999)).rejects.toMatchObject({
+      response: { status: 404 },
+    });
+  });
+
+  test('GET /routines/:id/days returns 200 ordered by dayNumber', async () => {
+    const routineId = await db.createRoutine('Days Test Routine', null, true);
+    routineIdsToClean.push(routineId);
+    await db.createWorkoutDay(routineId, 2, 'Day Two', null);
+    await db.createWorkoutDay(routineId, 1, 'Day One', null);
+
+    const body = await apiClient.getWorkoutDays(routineId);
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBe(2);
+    expect(body[0].dayNumber).toBeLessThanOrEqual(body[1].dayNumber);
+    expect(body[0].dayName).toBe('Day One');
+    expect(body[1].dayName).toBe('Day Two');
+  });
+
+  test('GET /routines/:id/days returns 404 for non-existent routine', async () => {
+    await expect(apiClient.getWorkoutDays(999999)).rejects.toMatchObject({
+      response: { status: 404 },
+    });
+  });
+});

--- a/test/component/workflows/weekly-report.test.ts
+++ b/test/component/workflows/weekly-report.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Component tests: GET /routines/:id/weekly-report
+ */
+
+import { logger } from '@chauhaidang/xq-harness-common-kit';
+import * as db from '../helpers/db-fixture';
+import { ApiClient } from '../helpers/api-client';
+
+const BASE_URL = process.env.API_BASE_URL || 'http://localhost:8080/xq-fitness-write-service/api/v1';
+const apiClient = new ApiClient(BASE_URL);
+
+const routineIdsToClean: number[] = [];
+
+afterEach(async () => {
+  for (const id of routineIdsToClean) {
+    try {
+      await db.deleteRoutine(id);
+    } catch (e) {
+      logger.warn(`Cleanup routine ${id} failed: ${e}`);
+    }
+  }
+  routineIdsToClean.length = 0;
+});
+
+describe('Component Test: Weekly Report', () => {
+  test('GET /routines/:id/weekly-report returns empty report when no snapshot', async () => {
+    const routineId = await db.createRoutine('Report No Snapshot Routine', null, true);
+    routineIdsToClean.push(routineId);
+
+    const body = await apiClient.getWeeklyReport(routineId);
+    expect(body.routineId).toBe(routineId);
+    expect(body.hasSnapshot).toBe(false);
+    expect(body.snapshotCreatedAt).toBeNull();
+    expect(Array.isArray(body.muscleGroupTotals)).toBe(true);
+    expect(Array.isArray(body.exerciseTotals)).toBe(true);
+    body.muscleGroupTotals.forEach((t) => expect(t.totalSets).toBe(0));
+  });
+
+  test('GET /routines/:id/weekly-report returns 404 for non-existent routine', async () => {
+    await expect(apiClient.getWeeklyReport(999999)).rejects.toMatchObject({
+      response: { status: 404 },
+    });
+  });
+
+  test('GET /routines/:id/weekly-report returns report with snapshot_exercises totals', async () => {
+    const weekStart = db.getCurrentWeekStart();
+    const routineId = await db.createRoutine('Report Snapshot Routine', null, true);
+    routineIdsToClean.push(routineId);
+    const dayId = await db.createWorkoutDay(routineId, 1, 'Push Day', null);
+    const snapshotId = await db.createSnapshot(routineId, weekStart);
+    const snapshotDayId = await db.createSnapshotWorkoutDay(snapshotId, dayId, 1, 'Push Day', null);
+    await db.createSnapshotExercise(snapshotDayId, 1, 'Bench Press', 1, 30, 135, 3, null);
+    await db.createSnapshotExercise(snapshotDayId, 2, 'Bench Press', 1, 40, 145, 3, null);
+
+    const body = await apiClient.getWeeklyReport(routineId);
+    expect(body.routineId).toBe(routineId);
+    expect(body.hasSnapshot).toBe(true);
+    expect(body.snapshotCreatedAt).toBeDefined();
+    expect(Array.isArray(body.exerciseTotals)).toBe(true);
+    const bench = body.exerciseTotals.find((e) => e.exerciseName === 'Bench Press');
+    expect(bench).toBeDefined();
+    expect(bench!.totalReps).toBe(40);
+    expect(bench!.totalWeight).toBe(145);
+    const chestTotal = body.muscleGroupTotals?.find((t) => t.muscleGroup?.id === 1);
+    expect(chestTotal).toBeDefined();
+    expect(chestTotal!.totalSets).toBe(6);
+  });
+
+  test('GET /routines/:id/weekly-report calculates progressive overload against previous week', async () => {
+    const routineId = await db.createRoutine('Progressive Overload Routine', null, true);
+    routineIdsToClean.push(routineId);
+
+    const currentWeekStart = db.getCurrentWeekStart();
+    const previousWeekStart = db.getPreviousWeekStart(1);
+
+    const dayId = await db.createWorkoutDay(routineId, 1, 'Full Body', null);
+
+    const prevSnapshotId = await db.createSnapshot(routineId, previousWeekStart);
+    const prevSnapshotDayId = await db.createSnapshotWorkoutDay(prevSnapshotId, dayId, 1, 'Full Body', null);
+
+    await db.createSnapshotExercise(prevSnapshotDayId, 1, 'Bench Press', 1, 30, 135, 3, null);
+    await db.createSnapshotExercise(prevSnapshotDayId, 2, 'Squat', 3, 20, 200, 4, null);
+    await db.createSnapshotExercise(prevSnapshotDayId, 3, 'Deadlift', 4, 15, 225, 3, null);
+
+    const currSnapshotId = await db.createSnapshot(routineId, currentWeekStart);
+    const currSnapshotDayId = await db.createSnapshotWorkoutDay(currSnapshotId, dayId, 1, 'Full Body', null);
+
+    await db.createSnapshotExercise(currSnapshotDayId, 4, 'Bench Press', 1, 35, 130, 3, null);
+    await db.createSnapshotExercise(currSnapshotDayId, 5, 'Squat', 3, 20, 210, 4, null);
+    await db.createSnapshotExercise(currSnapshotDayId, 6, 'Deadlift', 4, 10, 225, 3, null);
+    await db.createSnapshotExercise(currSnapshotDayId, 7, 'Lunges', 3, 40, 50, 4, null);
+
+    const body = await apiClient.getWeeklyReport(routineId, currentWeekStart);
+
+    expect(body.hasSnapshot).toBe(true);
+    expect(body.exerciseTotals).toHaveLength(4);
+
+    const bench = body.exerciseTotals.find((e) => e.exerciseName === 'Bench Press')!;
+    expect(bench.progressStatusRep).toBe('INCREASED');
+    expect(bench.progressStatusWeight).toBe('DECREASED');
+
+    const squat = body.exerciseTotals.find((e) => e.exerciseName === 'Squat')!;
+    expect(squat.progressStatusRep).toBe('MAINTAINED');
+    expect(squat.progressStatusWeight).toBe('INCREASED');
+
+    const deadlift = body.exerciseTotals.find((e) => e.exerciseName === 'Deadlift')!;
+    expect(deadlift.progressStatusRep).toBe('DECREASED');
+    expect(deadlift.progressStatusWeight).toBe('MAINTAINED');
+
+    const lunges = body.exerciseTotals.find((e) => e.exerciseName === 'Lunges')!;
+    expect(lunges.progressStatusRep).toBe('MAINTAINED');
+    expect(lunges.progressStatusWeight).toBe('MAINTAINED');
+  });
+
+  test('GET /routines/:id/weekly-report calculates progressive overload using max values from both weeks', async () => {
+    const routineId = await db.createRoutine('Max-Value Overload Routine', null, true);
+    routineIdsToClean.push(routineId);
+
+    const currentWeekStart = db.getCurrentWeekStart();
+    const previousWeekStart = db.getPreviousWeekStart(1);
+
+    const dayId = await db.createWorkoutDay(routineId, 1, 'Full Body', null);
+
+    const prevSnapshotId = await db.createSnapshot(routineId, previousWeekStart);
+    const prevSnapshotDayId = await db.createSnapshotWorkoutDay(prevSnapshotId, dayId, 1, 'Full Body', null);
+
+    await db.createSnapshotExercise(prevSnapshotDayId, 1, 'Bench Press', 1, 30, 135, 3, null);
+    await db.createSnapshotExercise(prevSnapshotDayId, 2, 'Bench Press', 1, 25, 140, 3, null);
+
+    const currSnapshotId = await db.createSnapshot(routineId, currentWeekStart);
+    const currSnapshotDayId = await db.createSnapshotWorkoutDay(currSnapshotId, dayId, 1, 'Full Body', null);
+
+    await db.createSnapshotExercise(currSnapshotDayId, 3, 'Bench Press', 1, 35, 130, 3, null);
+    await db.createSnapshotExercise(currSnapshotDayId, 4, 'Bench Press', 1, 32, 145, 3, null);
+
+    const body = await apiClient.getWeeklyReport(routineId, currentWeekStart);
+
+    const bench = body.exerciseTotals.find((e) => e.exerciseName === 'Bench Press')!;
+    expect(bench.progressStatusRep).toBe('INCREASED');
+    expect(bench.progressStatusWeight).toBe('INCREASED');
+    expect(bench.totalReps).toBe(32);
+    expect(bench.totalWeight).toBe(145);
+  });
+
+  test('GET /routines/:id/weekly-report sets progress status to MAINTAINED without previous snapshot', async () => {
+    const routineId = await db.createRoutine('No Prev Snapshot Routine', null, true);
+    routineIdsToClean.push(routineId);
+
+    const currentWeekStart = db.getCurrentWeekStart();
+    const dayId = await db.createWorkoutDay(routineId, 1, 'Push Day', null);
+
+    const snapshotId = await db.createSnapshot(routineId, currentWeekStart);
+    const snapshotDayId = await db.createSnapshotWorkoutDay(snapshotId, dayId, 1, 'Push Day', null);
+    await db.createSnapshotExercise(snapshotDayId, 1, 'Bench Press', 1, 30, 135, 3, null);
+
+    const body = await apiClient.getWeeklyReport(routineId, currentWeekStart);
+
+    expect(body.hasSnapshot).toBe(true);
+    const bench = body.exerciseTotals.find((e) => e.exerciseName === 'Bench Press')!;
+    expect(bench.progressStatusRep).toBe('MAINTAINED');
+    expect(bench.progressStatusWeight).toBe('MAINTAINED');
+  });
+
+  describe('weekStartDate query parameter', () => {
+    test('GET /routines/:id/weekly-report with weekStartDate returns snapshot from the specified previous week', async () => {
+      const previousWeekStart = db.getPreviousWeekStart(1);
+      const currentWeekStart = db.getCurrentWeekStart();
+
+      const routineId = await db.createRoutine('Previous Week Snapshot Routine', null, true);
+      routineIdsToClean.push(routineId);
+      const dayId = await db.createWorkoutDay(routineId, 1, 'Pull Day', null);
+
+      const prevSnapshotId = await db.createSnapshot(routineId, previousWeekStart);
+      const prevSnapshotDayId = await db.createSnapshotWorkoutDay(prevSnapshotId, dayId, 1, 'Pull Day', null);
+      await db.createSnapshotExercise(prevSnapshotDayId, 1, 'Deadlift', 1, 25, 225, 5, null);
+
+      const currSnapshotId = await db.createSnapshot(routineId, currentWeekStart);
+      const currSnapshotDayId = await db.createSnapshotWorkoutDay(currSnapshotId, dayId, 1, 'Pull Day', null);
+      await db.createSnapshotExercise(currSnapshotDayId, 2, 'Bench Press', 1, 40, 135, 3, null);
+
+      const body = await apiClient.getWeeklyReport(routineId, previousWeekStart);
+
+      expect(body.routineId).toBe(routineId);
+      expect(body.weekStartDate).toBe(previousWeekStart);
+      expect(body.hasSnapshot).toBe(true);
+      expect(body.snapshotCreatedAt).toBeDefined();
+      expect(body.exerciseTotals.find((e) => e.exerciseName === 'Bench Press')).toBeUndefined();
+      const deadlift = body.exerciseTotals.find((e) => e.exerciseName === 'Deadlift');
+      expect(deadlift).toBeDefined();
+      expect(deadlift!.totalReps).toBe(25);
+      expect(deadlift!.totalWeight).toBe(225);
+      const muscleTotal = body.muscleGroupTotals?.find((t) => t.muscleGroup?.id === 1);
+      expect(muscleTotal).toBeDefined();
+      expect(muscleTotal!.totalSets).toBe(5);
+    });
+
+    test('GET /routines/:id/weekly-report with weekStartDate returns empty report when no snapshot exists for that previous week', async () => {
+      const previousWeekStart = db.getPreviousWeekStart(2);
+      const routineId = await db.createRoutine('Previous Week No Snapshot Routine', null, true);
+      routineIdsToClean.push(routineId);
+      const currentWeekStart = db.getCurrentWeekStart();
+      const dayId = await db.createWorkoutDay(routineId, 1, 'Leg Day', null);
+      const snapshotId = await db.createSnapshot(routineId, currentWeekStart);
+      const snapshotDayId = await db.createSnapshotWorkoutDay(snapshotId, dayId, 1, 'Leg Day', null);
+      await db.createSnapshotExercise(snapshotDayId, 1, 'Squat', 3, 20, 185, 4, null);
+
+      const body = await apiClient.getWeeklyReport(routineId, previousWeekStart);
+
+      expect(body.routineId).toBe(routineId);
+      expect(body.weekStartDate).toBe(previousWeekStart);
+      expect(body.hasSnapshot).toBe(false);
+      expect(body.snapshotCreatedAt).toBeNull();
+      expect(Array.isArray(body.muscleGroupTotals)).toBe(true);
+      body.muscleGroupTotals.forEach((t) => expect(t.totalSets).toBe(0));
+      expect(body.exerciseTotals).toHaveLength(0);
+    });
+  });
+});

--- a/test/unit/controllers/readController.test.ts
+++ b/test/unit/controllers/readController.test.ts
@@ -1,0 +1,49 @@
+import request from 'supertest';
+import express from 'express';
+import * as readController from '../../../src/controllers/readController';
+
+jest.mock('../../../src/services/readService', () => ({
+  getAllMuscleGroups: jest.fn(),
+  getAllRoutines: jest.fn(),
+  getRoutineById: jest.fn(),
+  getWorkoutDaysByRoutineId: jest.fn(),
+  getExercisesByWorkoutDayId: jest.fn(),
+}));
+
+import * as readService from '../../../src/services/readService';
+
+const app = express();
+app.use(express.json());
+app.get('/api/v1/routines/:routineId', readController.getRoutineById);
+app.get('/api/v1/routines/:routineId/days', readController.getWorkoutDays);
+app.get('/api/v1/exercises', readController.getExercises);
+
+describe('readController error paths', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('getRoutineById returns 400 for invalid id', async () => {
+    const res = await request(app).get('/api/v1/routines/not-a-number');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('BAD_REQUEST');
+  });
+
+  test('getRoutineById returns 404 when not found', async () => {
+    (readService.getRoutineById as jest.Mock).mockResolvedValue(null);
+    const res = await request(app).get('/api/v1/routines/42');
+    expect(res.status).toBe(404);
+  });
+
+  test('getWorkoutDays returns 404 when routine has no days', async () => {
+    (readService.getWorkoutDaysByRoutineId as jest.Mock).mockResolvedValue([]);
+    const res = await request(app).get('/api/v1/routines/42/days');
+    expect(res.status).toBe(404);
+  });
+
+  test('getExercises returns 400 when workoutDayId missing', async () => {
+    const res = await request(app).get('/api/v1/exercises');
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('workoutDayId');
+  });
+});

--- a/test/unit/controllers/reportController.test.ts
+++ b/test/unit/controllers/reportController.test.ts
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import express from 'express';
+import * as reportController from '../../../src/controllers/reportController';
+
+jest.mock('../../../src/services/reportService', () => ({
+  getWeeklyReport: jest.fn(),
+}));
+
+import * as reportService from '../../../src/services/reportService';
+
+const app = express();
+app.use(express.json());
+app.get('/api/v1/routines/:routineId/weekly-report', reportController.getWeeklyReport);
+
+describe('reportController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns 400 for invalid routineId', async () => {
+    const res = await request(app).get('/api/v1/routines/abc/weekly-report');
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 404 when routine not found', async () => {
+    (reportService.getWeeklyReport as jest.Mock).mockRejectedValue(new Error('Routine not found: 99'));
+    const res = await request(app).get('/api/v1/routines/99/weekly-report');
+    expect(res.status).toBe(404);
+  });
+
+  test('returns 200 with weekly report', async () => {
+    (reportService.getWeeklyReport as jest.Mock).mockResolvedValue({
+      routineId: 1,
+      weekStartDate: '2024-12-02',
+      hasSnapshot: false,
+      snapshotCreatedAt: null,
+      muscleGroupTotals: [],
+      exerciseTotals: [],
+    });
+    const res = await request(app).get('/api/v1/routines/1/weekly-report');
+    expect(res.status).toBe(200);
+    expect(res.body.routineId).toBe(1);
+  });
+});

--- a/test/unit/read-routes.test.ts
+++ b/test/unit/read-routes.test.ts
@@ -1,0 +1,30 @@
+import request from 'supertest';
+import express from 'express';
+import * as readController from '../../src/controllers/readController';
+
+jest.mock('../../src/services/readService', () => ({
+  getAllMuscleGroups: jest.fn().mockResolvedValue([]),
+  getAllRoutines: jest.fn().mockResolvedValue([]),
+  getRoutineById: jest.fn().mockResolvedValue(null),
+  getWorkoutDaysByRoutineId: jest.fn().mockResolvedValue([]),
+  getExercisesByWorkoutDayId: jest.fn().mockResolvedValue([]),
+}));
+
+const app = express();
+app.use(express.json());
+app.get('/api/v1/muscle-groups', readController.getMuscleGroups);
+app.get('/api/v1/routines', readController.getRoutines);
+
+describe('ReadController', () => {
+  test('GET /api/v1/muscle-groups returns 200 and array', async () => {
+    const res = await request(app).get('/api/v1/muscle-groups');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  test('GET /api/v1/routines returns 200 and array', async () => {
+    const res = await request(app).get('/api/v1/routines');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});

--- a/test/unit/routes/merged-routes.test.ts
+++ b/test/unit/routes/merged-routes.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import express from 'express';
+import routes from '../../../src/routes';
+
+jest.mock('../../../src/services/readService', () => ({
+  getAllMuscleGroups: jest.fn().mockResolvedValue([]),
+  getAllRoutines: jest.fn().mockResolvedValue([]),
+  getRoutineById: jest.fn().mockResolvedValue(null),
+  getWorkoutDaysByRoutineId: jest.fn().mockResolvedValue([]),
+  getExercisesByWorkoutDayId: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../../src/services/reportService', () => ({
+  getWeeklyReport: jest.fn(),
+}));
+
+jest.mock('../../../src/controllers/routineController', () => ({
+  RoutineController: {
+    createRoutine: jest.fn((_req: express.Request, res: express.Response) => res.status(201).json({ id: 1 })),
+    updateRoutine: jest.fn((_req: express.Request, res: express.Response) => res.status(200).json({ id: 1 })),
+    deleteRoutine: jest.fn((_req: express.Request, res: express.Response) => res.sendStatus(204)),
+  },
+}));
+
+jest.mock('../../../src/controllers/exerciseController', () => ({
+  ExerciseController: {
+    createExercise: jest.fn((_req: express.Request, res: express.Response) => res.status(201).json({ id: 1 })),
+    getExercise: jest.fn((_req: express.Request, res: express.Response) => res.status(200).json({ id: 1 })),
+    updateExercise: jest.fn((_req: express.Request, res: express.Response) => res.status(200).json({ id: 1 })),
+    deleteExercise: jest.fn((_req: express.Request, res: express.Response) => res.sendStatus(204)),
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1', routes);
+
+describe('merged routes', () => {
+  test('GET /exercises list is registered before GET /exercises/:id', async () => {
+    const listRes = await request(app).get('/api/v1/exercises');
+    expect(listRes.status).toBe(400);
+
+    const byIdRes = await request(app).get('/api/v1/exercises/1');
+    expect(byIdRes.status).toBe(200);
+  });
+
+  test('GET /muscle-groups is available', async () => {
+    const res = await request(app).get('/api/v1/muscle-groups');
+    expect(res.status).toBe(200);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,6 +1161,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cookiejar@npm:^2.1.5":
+  version: 2.1.5
+  resolution: "@types/cookiejar@npm:2.1.5"
+  checksum: 10c0/af38c3d84aebb3ccc6e46fb6afeeaac80fb26e63a487dd4db5a8b87e6ad3d4b845ba1116b2ae90d6f886290a36200fa433d8b1f6fe19c47da6b81872ce9a2764
+  languageName: node
+  linkType: hard
+
 "@types/cors@npm:^2.8.19":
   version: 2.8.19
   resolution: "@types/cors@npm:2.8.19"
@@ -1244,6 +1251,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/methods@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@types/methods@npm:1.1.4"
+  checksum: 10c0/a78534d79c300718298bfff92facd07bf38429c66191f640c1db4c9cff1e36f819304298a96f7536b6512bfc398e5c3e6b831405e138cd774b88ad7be78d682a
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 26.0.0
   resolution: "@types/node@npm:26.0.0"
@@ -1310,6 +1324,28 @@ __metadata:
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
   checksum: 10c0/1f4658385ae936330581bcb8aa3a066df03867d90281cdf89cc356d404bd6579be0f11902304e1f775d92df22c6dd761d4451c804b0a4fba973e06211e9bd77c
+  languageName: node
+  linkType: hard
+
+"@types/superagent@npm:^8.1.0":
+  version: 8.1.10
+  resolution: "@types/superagent@npm:8.1.10"
+  dependencies:
+    "@types/cookiejar": "npm:^2.1.5"
+    "@types/methods": "npm:^1.1.4"
+    "@types/node": "npm:*"
+    form-data: "npm:^4.0.0"
+  checksum: 10c0/cd911f7e926aae3f23caeebac055c46c5a63576561548356e0ca809147b372a27359112e02a569d527fd677cd90ee6d018b5cdf509a0a5ac70f74289bd29c9bc
+  languageName: node
+  linkType: hard
+
+"@types/supertest@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "@types/supertest@npm:6.0.3"
+  dependencies:
+    "@types/methods": "npm:^1.1.4"
+    "@types/superagent": "npm:^8.1.0"
+  checksum: 10c0/a2080f870154b09db123864a484fb633bc9e2a0f7294a194388df4c7effe5af9de36d5a5ebf819f72b404fa47b5e813c47d5a3a51354251fd2fa8589bfb64f2c
   languageName: node
   linkType: hard
 
@@ -2922,7 +2958,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.5":
+"form-data@npm:^4.0.0, form-data@npm:^4.0.5":
   version: 4.0.6
   resolution: "form-data@npm:4.0.6"
   dependencies:
@@ -5832,10 +5868,10 @@ __metadata:
 
 "xq-fitness-write-client@file:./generated-clients/write-service::locator=xq-fitness-write-service%40workspace%3A.":
   version: 1.0.0
-  resolution: "xq-fitness-write-client@file:./generated-clients/write-service#./generated-clients/write-service::hash=421771&locator=xq-fitness-write-service%40workspace%3A."
+  resolution: "xq-fitness-write-client@file:./generated-clients/write-service#./generated-clients/write-service::hash=72194b&locator=xq-fitness-write-service%40workspace%3A."
   dependencies:
     axios: "npm:^1.6.1"
-  checksum: 10c0/e8ac47f1b7bf39f7eefb3bcc697307b38b786ecc4785c3c28c9e924c4f27e7367efbf2ed65634519bbbfb54f080c978de903bf311f0878400bb802604819e8a8
+  checksum: 10c0/1221121cfdbea2db0af8e924857d7c010ab458c49fa2b03ee21edde74303a250a9aaee3815471e7e51771e0f331341851703b64e84919640d01269657bdec7d5
   languageName: node
   linkType: hard
 
@@ -5851,6 +5887,7 @@ __metadata:
     "@types/joi": "npm:^17.2.2"
     "@types/node": "npm:^22.5.0"
     "@types/pg": "npm:^8.16.0"
+    "@types/supertest": "npm:^6.0.3"
     "@types/wait-on": "npm:^5.3.4"
     "@typescript-eslint/eslint-plugin": "npm:^7.0.0"
     "@typescript-eslint/parser": "npm:^7.0.0"


### PR DESCRIPTION
## Summary
- Merged former read-service GET handlers (muscle groups, routines, days, exercises, weekly report) into write-service routes and services behind a single OpenAPI **v2.1.0** contract.
- Updated `api/write-service-api.yaml`, regenerated client usage in component tests, added unit/route tests and read workflow component tests with DB fixture support.
- Documented unified gateway path and manual read-service retirement steps in README; CI path filters now include `test/**`.

## Test plan
- [ ] `yarn build`
- [ ] `yarn test:unit`
- [ ] `yarn lint` / `yarn format:check`
- [ ] `yarn test:component:local` (xq-infra gateway on `:8080`)
- [ ] Smoke via gateway: `GET /xq-fitness-write-service/health` and read endpoints listed below
- [ ] Verify existing write flows (create/update routine, snapshot) unchanged

## Mobile integration guideline (for mobile team)

### Gateway path change
Read traffic should use the **write-service** gateway prefix, not the legacy read prefix:

| Before | After |
|--------|--------|
| `{GATEWAY}/xq-fitness-read-service/api/v1` | `{GATEWAY}/xq-fitness-write-service/api/v1` |

Example local gateway: `http://localhost:8080/xq-fitness-write-service/api/v1`

### API paths unchanged
Resource paths under `/api/v1` are the same as on read-service (only the gateway component prefix changes).

### Endpoint inventory (GET — now served by write-service)
| Method | Path | Notes |
|--------|------|--------|
| GET | `/muscle-groups` | List muscle groups |
| GET | `/routines` | Optional `?isActive=` |
| GET | `/routines/{routineId}` | Full routine detail |
| GET | `/routines/{routineId}/days` | Workout days for routine |
| GET | `/routines/{routineId}/weekly-report` | Optional `?weekStartDate=` |
| GET | `/exercises` | Query: `workoutDayId`, optional `muscleGroupId` |
| GET | `/exercises/{exerciseId}` | Single exercise |

Write endpoints (POST/PUT/DELETE) remain on the same base URL and paths as before.

### Response schema notes (OpenAPI)
- **List/detail reads** use `WorkoutRoutine`, `WorkoutRoutineDetail`, `WorkoutDayDetail`, `Exercise`, `MuscleGroup`, and `WeeklyReportResponse` in `write-service-api.yaml`.
- **Write responses** continue to use `RoutineResponse`, `WorkoutDayResponse`, etc. where defined for mutating operations.
- Mobile parsers that already matched read-service JSON should align with the unified spec; compare any field renames against OpenAPI v2.1.0 rather than the old read-service YAML.

### Backward compatibility
- Nginx (or gateway) **may** keep a `/xq-fitness-read-service/` alias forwarding to write-service during migration; treat as optional safety net, not the long-term contract.
- No intentional breaking changes to write endpoints or paths.

### Deployment order
1. Deploy **write-service** with merged read routes (this PR).
2. Ship mobile build pointing all reads at `/xq-fitness-write-service/api/v1`.
3. Soak in production; keep read-service DO component running for rollback.
4. Manually remove read-service from the DigitalOcean app after soak (see README — not automated in CI).
5. Optionally retire read-service repo/CI after confidence period.

### What mobile already changed (`mobile/src/services/api.js`)
- `WRITE_SERVICE_URL` = `` `${GATEWAY_URL}/xq-fitness-write-service/api/v1` ``
- `READ_SERVICE_URL` is set to **`WRITE_SERVICE_URL`** (alias), so read and write clients share the unified base URL in the monorepo mobile app.

### Mobile testing checklist
- [ ] Home / routine list (`GET /routines`, active filter if used)
- [ ] Open routine detail (`GET /routines/{id}`)
- [ ] Workout days list (`GET /routines/{id}/days`)
- [ ] Exercise picker (`GET /exercises` with day + muscle group)
- [ ] Muscle groups reference data (`GET /muscle-groups`)
- [ ] Weekly report screen (`GET /routines/{id}/weekly-report`)
- [ ] Regression: create/edit routine, log sets, weekly snapshot (write paths)
- [ ] Confirm against staging/prod gateway using **write-service** prefix only


Made with [Cursor](https://cursor.com)